### PR TITLE
Implement download and remote-listing capabilities

### DIFF
--- a/wrapper.py
+++ b/wrapper.py
@@ -31,24 +31,25 @@ class nc_wrapper:
         self.basic_auth_headers = { "username":user_val, "password":pass_val }
         self.auth_tuple = ( user_val, pass_val )
     
-    def download(self, suffix):
-        full_url = self.base_url+suffix
+    def download(self, suffix, filename):
+        full_url = self.base_url + suffix + filename
 
-        result = requests.request(method="GET", url=full_url, auth=self.auth_tuple, timeout=60.0, verify=True)
+        result = requests.request(method="GET", url=full_url, headers={"OCS-APIRequest": "true"}, auth=self.auth_tuple, timeout=60.0, verify=True)
         if (result.status_code == 200):
-            return result.content
-        else:
-            return result.reason
+            output_f = open(filename, "wb")
+            output_f.write(result.content)
+            output_f.close()
+        return result.reason
 
-    def list():
-        full_url = self.base_url+suffix
+    def list(self, path):
+        full_url = self.base_url+path
         
         result = requests.request(method="PROPFIND", url=full_url, auth=self.auth_tuple, timeout=60.0, verify=True)
         print(result.status_code)
         print(result.reason)
         print(result.content)
     
-    def upload(self, filename, destination):
+    def upload(self, dest_path, filename):
         all_headers = {}
         full_url = self.base_url+suffix
         #result = requests.request(method="POST", url=full_url, headers=, timeout=60.0, verify=True)
@@ -68,6 +69,13 @@ if __name__ == '__main__':
     # Now for the real test: try to LIST remote files, using WebDAV
     #if (server_link[-1] == "/"):
     #else:
-    get_text = nc_wrapper.list("/remote.php/dav/files/"+user+"/Documents/")
+
+    # List remote files in a server-side Documents directory
+    #list_text = nc_wrapper.list("/remote.php/dav/files/"+user+"/Documents/")
+    #print(list_text)
+    
+    # Download a remote file
+    file_to_retrieve = "ale-video-slides---megumin-math-problem.odp"
+    get_text = nc_wrapper.download("/remote.php/dav/files/"+user+"/Documents/", file_to_retrieve)
     print(get_text)
 

--- a/wrapper.py
+++ b/wrapper.py
@@ -33,13 +33,20 @@ class nc_wrapper:
     
     def download(self, suffix):
         full_url = self.base_url+suffix
-        print("Now trying %s" % full_url)
 
         result = requests.request(method="GET", url=full_url, auth=self.auth_tuple, timeout=60.0, verify=True)
         if (result.status_code == 200):
             return result.content
         else:
             return result.reason
+
+    def list():
+        full_url = self.base_url+suffix
+        
+        result = requests.request(method="PROPFIND", url=full_url, auth=self.auth_tuple, timeout=60.0, verify=True)
+        print(result.status_code)
+        print(result.reason)
+        print(result.content)
     
     def upload(self, filename, destination):
         all_headers = {}
@@ -58,9 +65,9 @@ if __name__ == '__main__':
     passwd = getpass.getpass()
     nc_wrapper = nc_wrapper(server_link, user, passwd)
 
-    # Now for the real test: try a GET request using WebDAV!
+    # Now for the real test: try to LIST remote files, using WebDAV
     #if (server_link[-1] == "/"):
     #else:
-    get_text = nc_wrapper.download("/remote.php/dav/files/"+user+"/Documents/")
+    get_text = nc_wrapper.list("/remote.php/dav/files/"+user+"/Documents/")
     print(get_text)
 

--- a/wrapper.py
+++ b/wrapper.py
@@ -1,12 +1,66 @@
-import requests
+#!/usr/bin/env python3
+"""
 
-class nc_wrapper():
-    def __init__(self):
-        pass
+    A program meant to wrap a client's simple HTTPS calls
+    to the Nextcloud server.
+
+    Requests documentation: https://docs.python-requests.org/en/master/api/
     
-    def run(self):
+    This test actually demonstrates how the python requests API will NOT be
+    sufficient for accessing files using webDAV urls.
+
+    An example execution I/O excerpt is:
+    ```
+    server name: https://www.example.com/nextcloud
+    username: chozorho
+    Password:
+    Now trying https://www.example.com/nextcloud/remote.php/dav/files/chozorho/Documents/
+    b'This is the WebDAV interface. It can only be accessed by WebDAV clients such as the Nextcloud desktop sync client.'
+    ```
+
+    So we'll need to use a different API.
+
+"""
+import getpass, requests
+
+
+
+class nc_wrapper:
+    def __init__(self, nc_url, user_val, pass_val):
+        self.base_url = nc_url
+        self.basic_auth_headers = { "username":user_val, "password":pass_val }
+        self.auth_tuple = ( user_val, pass_val )
+    
+    def download(self, suffix):
+        full_url = self.base_url+suffix
+        print("Now trying %s" % full_url)
+
+        result = requests.request(method="GET", url=full_url, auth=self.auth_tuple, timeout=60.0, verify=True)
+        if (result.status_code == 200):
+            return result.content
+        else:
+            return result.reason
+    
+    def upload(self, filename, destination):
+        all_headers = {}
+        full_url = self.base_url+suffix
+        #result = requests.request(method="POST", url=full_url, headers=, timeout=60.0, verify=True)
         pass
     
 if __name__ == '__main__':
-    nc_wrapper = nc_wrapper()
-    nc_wrapper.run()
+    # TODO ensure that this authentication strategy
+    # truly is secure (and doesn't leak any passwords)!
+    # Sooner or later, I can use Wireshark to do this.
+
+    # Get user input for the actual arguments
+    server_link = input("server name: ")
+    user = input("username: ")
+    passwd = getpass.getpass()
+    nc_wrapper = nc_wrapper(server_link, user, passwd)
+
+    # Now for the real test: try a GET request using WebDAV!
+    #if (server_link[-1] == "/"):
+    #else:
+    get_text = nc_wrapper.download("/remote.php/dav/files/"+user+"/Documents/")
+    print(get_text)
+

--- a/wrapper.py
+++ b/wrapper.py
@@ -5,20 +5,6 @@
     to the Nextcloud server.
 
     Requests documentation: https://docs.python-requests.org/en/master/api/
-    
-    This test actually demonstrates how the python requests API will NOT be
-    sufficient for accessing files using webDAV urls.
-
-    An example execution I/O excerpt is:
-    ```
-    server name: https://www.example.com/nextcloud
-    username: chozorho
-    Password:
-    Now trying https://www.example.com/nextcloud/remote.php/dav/files/chozorho/Documents/
-    b'This is the WebDAV interface. It can only be accessed by WebDAV clients such as the Nextcloud desktop sync client.'
-    ```
-
-    So we'll need to use a different API.
 
 """
 import getpass, requests


### PR DESCRIPTION
For details, see comments or run tests on your own terminal. The old PR (#2) was closed automatically when I renamed the source branch. :sweat: 

I still maintain that similar functionality has already been implemented by people like [Dosugamea](https://github.com/Dosugamea/NEXT-OCS-API-forPy/blob/master/NextCloud.py), but still, it's worth reading and experimenting with the requests API.